### PR TITLE
Added the missed required method

### DIFF
--- a/src/SelectelAdapter.php
+++ b/src/SelectelAdapter.php
@@ -287,4 +287,9 @@ class SelectelAdapter implements AdapterInterface
     {
         return $this->container->url($path);
     }
+    
+    public function getPathPrefix()
+    {
+        return '/';
+    }
 }


### PR DESCRIPTION
When we try to get the path to the file using the path() method, we get an error
```
$path = Storage::disk('selectel')->path('some/path/test.txt');
```

```
Call to undefined method ArgentCrusade\Flysystem\Selectel\SelectelAdapter::getPathPrefix()
```
![image](https://user-images.githubusercontent.com/3227797/101998983-40f86800-3ce9-11eb-8c8b-4948e489ef3c.png)
